### PR TITLE
Fixed encoding issue with MRI 1.9.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 maintainer       "Jorge Falcão"
 maintainer_email "falcao@intelie.com.br"
 license          "Apache 2.0"


### PR DESCRIPTION
Hi.

It is necessary to set the encoding to `utf-8` since Ruby 1.9.x when using non ASCII characters, such as your name in `metadata.rb`. I added the `encoding: utf-8` in `metadata.rb` and now it properly works under MRI 1.9.x.
