### PR TITLE
Notification was referencing a template instead of file resource.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ install_from_release('jruby') do
   checksum node[:jruby][:checksum]
   has_binaries  %w(bin/jgem bin/jruby bin/jirb)
   not_if       { File.exists?(prefix) }
-  notifies :create_if_missing, "template[/etc/profile.d/jruby.sh]", :notification_timing
+  notifies :create_if_missing, "file[/etc/profile.d/jruby.sh]"
 end
 
 if node[:jruby][:nailgun]


### PR DESCRIPTION
This was causing the Chef run to fail on a clean Vagrant box.  Replacing the reference to `template` to `file` remedies the issue.

Thanks for open sourcing your cookbook.
