### PR TITLE
Added missing option :immediate to 'notifies'

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ install_from_release('jruby') do
   checksum node[:jruby][:checksum]
   has_binaries  %w(bin/jgem bin/jruby bin/jirb)
   not_if       { File.exists?(prefix) }
-  notifies :create_if_missing, "file[/etc/profile.d/jruby.sh]"
+  notifies :create_if_missing, "file[/etc/profile.d/jruby.sh]", :immediate
 end
 
 if node[:jruby][:nailgun]


### PR DESCRIPTION
Fixes the following error:
## ArgumentError

invalid timing: imediately for notifies(create_if_missing, ["file[/etc/profile.d/jruby.sh]"], imediately) resource install_from_release[jruby] Valid timings are: :delayed, :immediate, :immediately
