### PR TITLE
Gem installation fails when gems are set in default attributes.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,7 @@ end
 # install all gems defined in the module
 node[:jruby][:gems].each do |gem|
   if gem.is_a? Hash
-    name = gem.delete(:name)
+    name = gem[:name]
   else
     name = gem
     gem = nil


### PR DESCRIPTION
If gems are set in the default attributes of the including library, gem installation will fail.
This is because the default attributes are immutable, so they cannot be deleted.